### PR TITLE
separate witness generation steps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "witness"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ark-bn254",
  "ark-ff 0.4.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witness"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,24 +1,31 @@
 use std::{collections::HashMap, ops::Shl};
 
 use crate::field::M;
+use ark_bn254::Fr;
+use ark_ff::PrimeField;
 use rand::Rng;
 use ruint::aliases::U256;
 use serde::{Deserialize, Serialize};
-use ark_bn254::Fr;
-use ark_ff::PrimeField;
 
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Compress, Validate};
 
-fn ark_se<S, A: CanonicalSerialize>(a: &A, s: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
-      let mut bytes = vec![];
-      a.serialize_with_mode(&mut bytes, Compress::Yes).map_err(serde::ser::Error::custom)?;
-      s.serialize_bytes(&bytes)
+fn ark_se<S, A: CanonicalSerialize>(a: &A, s: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let mut bytes = vec![];
+    a.serialize_with_mode(&mut bytes, Compress::Yes)
+        .map_err(serde::ser::Error::custom)?;
+    s.serialize_bytes(&bytes)
 }
 
-fn ark_de<'de, D, A: CanonicalDeserialize>(data: D) -> Result<A, D::Error> where D: serde::de::Deserializer<'de> {
-      let s: Vec<u8> = serde::de::Deserialize::deserialize(data)?;
-      let a = A::deserialize_with_mode(s.as_slice(), Compress::Yes, Validate::Yes);
-      a.map_err(serde::de::Error::custom)
+fn ark_de<'de, D, A: CanonicalDeserialize>(data: D) -> Result<A, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    let s: Vec<u8> = serde::de::Deserialize::deserialize(data)?;
+    let a = A::deserialize_with_mode(s.as_slice(), Compress::Yes, Validate::Yes);
+    a.map_err(serde::de::Error::custom)
 }
 
 #[derive(Hash, PartialEq, Eq, Debug, Clone, Copy, Serialize, Deserialize)]
@@ -34,7 +41,7 @@ pub enum Operation {
     Leq,
     Geq,
     Lor,
-    Shl
+    Shl,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -74,7 +81,6 @@ impl Operation {
             _ => unimplemented!("operator {:?} not implemented for Montgomery", self),
         }
     }
-
 }
 
 fn compute_shl_uint(a: U256, b: U256) -> U256 {


### PR DESCRIPTION
For very small circuits the overhead of assigning inputs dominates. This is unnecessary since the positions for the inputs can be only calculated once (useful if one wants to execute the same circuit with different inputs many times).
This PR separates the individual steps in the witness generation and exports them individually for separated use.