### PR TITLE
fix: fixes links to old witness name

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -35,7 +35,7 @@ fn main() {
             .flag_if_supported("-w")
             .flag_if_supported("-d")
             .flag_if_supported("-g")
-            .compile("witness");
+            .compile("circom-witness-rs");
 
         println!("cargo:rerun-if-changed=src/main.rs");
         println!("cargo:rerun-if-changed=src/circuit.cc");

--- a/script/replace.sh
+++ b/script/replace.sh
@@ -10,8 +10,8 @@ filename=$(basename "$1" .cpp)
 
 # Add header
 cat <<EOT > "$filename.new"
-#include "witness/include/witness.h"
-#include "witness/src/generate.rs.h"
+#include "circom-witness-rs/include/witness.h"
+#include "circom-witness-rs/src/generate.rs.h"
 
 /// We need this accessor since cxx doesn't support hashmaps yet
 class IOSignalInfoAccessor {

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -99,7 +99,7 @@ mod ffi {
 
     // C++ types and signatures exposed to Rust.
     unsafe extern "C++" {
-        include!("witness/include/witness.h");
+        include!("circom-witness-rs/include/witness.h");
 
         unsafe fn run(ctx: *mut Circom_CalcWit);
         fn get_size_of_io_map() -> u32;


### PR DESCRIPTION
We had some problems in our fork after the rename. Fixed some references to old name (fixes our problems)