### PR TITLE
Update to use arkff-06

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,19 +12,19 @@ authors = [
 ]
 
 [dependencies]
-ark-bn254 = { version = "0.5", features = ["std"] }
-ark-ff = { version = "0.5", features = ["std"] }
-ark-serialize = { version = "0.5", features = ["derive"] }
+ark-bn254 = { version = "0.6.0", default-features = false, features = ["curve"] }
+ark-ff = { version = "0.6.0", default-features = false, features = ["std"] }
+ark-serialize = { version = "0.6.0", default-features = false, features = ["derive"] }
 byteorder = "1"
 cxx = { version = "1", optional = true }
 eyre = "0.6"
 hex = "0.4"
 postcard = { version = "1", features = ["use-std"], default-features = false }
 rand = "0.8"
-ruint = { version = "1.17", features = ["rand", "serde", "ark-ff-05", "num-bigint"] }
+ruint = { git = "https://github.com/alloy-rs/ruint", features = ["rand", "serde", "ark-ff-06", "num-bigint"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-num-bigint = "0.4"
+num-bigint = { version = "0.4.6", default-features = false }
 num-traits = "0.2"
 
 [build-dependencies]


### PR DESCRIPTION
Updates lib to work with arkworks/ruint 0.6 version