### PR TITLE
build(deps)!: update arkworks to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,16 +12,16 @@ authors = [
 ]
 
 [dependencies]
-ark-bn254 = { version = "0.5", features = ["std"] }
-ark-ff = { version = "0.5", features = ["std"] }
-ark-serialize = { version = "0.5", features = ["derive"] }
+ark-bn254 = { version = "0.6", features = ["std"] }
+ark-ff = { version = "0.6", features = ["std"] }
+ark-serialize = { version = "0.6", features = ["derive"] }
 byteorder = "1"
 cxx = { version = "1", optional = true }
 eyre = "0.6"
 hex = "0.4"
 postcard = { version = "1", features = ["use-std"], default-features = false }
 rand = "0.8"
-ruint = { version = "1.17", features = ["rand", "serde", "ark-ff-05", "num-bigint"] }
+ruint = { version = "1.19", features = ["rand", "serde", "ark-ff-06", "num-bigint"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 num-bigint = "0.4"


### PR DESCRIPTION
Bumps ark-{bn254,ff,serialize} from 0.5 to 0.6 and ruint from 1.17 to 1.19, switching the `ark-ff-05` feature to `ark-ff-06`.

We would like to update our crates to 0.6 at some point so this would be nice to release as 0.3?