### PR TITLE
Support input-dependent Circom runtime IR

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The repository contains two crates with a graph file as their boundary:
 1. `circom-witness-graph-builder` compiles a circuit into a static execution graph as a one-off operation.
 2. `circom-witness-rs` loads that graph and generates witness elements at runtime.
 
-In the first mode, it compiles the circuit in-process with Circom 2.2.2 and symbolically executes the compiler's typed witness IR to build an execution graph. No generated C++, native compiler, or Rust/C++ bridge is involved. The graph is optimized through constant propagation and dead code elimination, then lowered into a compact execution program with fused linear combinations, squaring, and multi-output power-of-five instructions. Constants and coefficients are pooled, references are backward-delta encoded, and the result is compressed with Zstandard. At runtime, independent field divisions are scheduled into batches that use one fast modular inversion per batch. The graph can be embedded in the binary and interpreted to generate the witness. Legacy compressed and uncompressed Postcard graphs remain readable.
+In the first mode, it compiles the circuit in-process with Circom 2.2.2 and symbolically executes the compiler's typed witness IR to build an execution graph. No generated C++, native compiler, or Rust/C++ bridge is involved. The graph is optimized through constant propagation and dead code elimination, then lowered into a compact execution program with fused linear combinations, squaring, and multi-output power-of-five instructions. Constants and coefficients are pooled, references are backward-delta encoded, and the result is compressed with Zstandard. At runtime, independent field divisions are scheduled into batches that use one fast modular inversion per batch. Input-dependent function branches, loops, and array indexes are embedded as portable Circom IR and interpreted only at those graph boundaries; the rest of the witness remains precomputed. The graph can be embedded in the binary and interpreted to generate the witness. Legacy compressed and uncompressed Postcard graphs remain readable.
 
 ## Usage
 
@@ -21,6 +21,7 @@ cargo run --release -p circom-witness-graph-builder -- circuit.circom graph.bin
 ```
 
 Additional arguments are treated as Circom library search paths.
+For circuits whose reference artifacts use Circom O1, put `--O1` before the circuit path.
 
 **2. (At runtime) Generate witness:**
 ```rust
@@ -32,11 +33,11 @@ fn main() {
 }
 ```
 
-**📦 Blackbox functions**
+**📦 Dynamic control flow and black-box functions**
 
-Unconstrained control flow is also supported through configurable blackbox functions. This also includes the commonly requested ternary operator. Importantly, any unconstained / dynamic control flow needs to live in circom functions (i.e. cannot live in templates), so requires small modifications to existing circuits. Those functions are currently limited to a single return value. 
+Input-dependent control flow in Circom functions is handled automatically by the runtime IR interpreter, including multi-value returns. Dynamic template branches with only local variable and signal effects are lowered to arithmetic selects. Branches that create or conditionally execute components are still rejected.
 
-*Important:* Those functions only get hooked iff you prefix them with `bbf*`.
+Black-box callbacks remain available as an explicit escape hatch or native acceleration hook. A Circom function is routed to a callback only when its name starts with `bbf`; callbacks return one field element.
 
 ```rust
     let mut bbfs: HashMap<String, BlackBoxFunction> = HashMap::new();

--- a/graph-builder/Cargo.toml
+++ b/graph-builder/Cargo.toml
@@ -12,10 +12,10 @@ authors = [
 
 [dependencies]
 circom-witness-rs = { path = "..", version = "0.4.0" }
-circom-compiler = { package = "compiler", git = "https://github.com/iden3/circom.git", rev = "e410b0d5cd2948a15931df0bc50d79ce56fa8c32" }
-circom-constraint-generation = { package = "constraint_generation", git = "https://github.com/iden3/circom.git", rev = "e410b0d5cd2948a15931df0bc50d79ce56fa8c32" }
-circom-parser = { package = "parser", git = "https://github.com/iden3/circom.git", rev = "e410b0d5cd2948a15931df0bc50d79ce56fa8c32" }
-circom-type-analysis = { package = "type_analysis", git = "https://github.com/iden3/circom.git", rev = "e410b0d5cd2948a15931df0bc50d79ce56fa8c32" }
+circom-compiler = { package = "compiler", git = "https://github.com/iden3/circom.git", rev = "6f782d7313793b3dc18cc3b38d2335eead9f5d50" }
+circom-constraint-generation = { package = "constraint_generation", git = "https://github.com/iden3/circom.git", rev = "6f782d7313793b3dc18cc3b38d2335eead9f5d50" }
+circom-parser = { package = "parser", git = "https://github.com/iden3/circom.git", rev = "6f782d7313793b3dc18cc3b38d2335eead9f5d50" }
+circom-type-analysis = { package = "type_analysis", git = "https://github.com/iden3/circom.git", rev = "6f782d7313793b3dc18cc3b38d2335eead9f5d50" }
 eyre = "0.6"
 rand = "0.8"
 ruint = { version = "1.19", features = ["rand", "ark-ff-06"] }

--- a/graph-builder/README.md
+++ b/graph-builder/README.md
@@ -4,8 +4,14 @@ This crate compiles Circom 2.2.2 circuits and emits optimized graph files for th
 
 It links directly to Circom's compiler crates and is therefore distributed under `GPL-3.0-only`. Runtime applications do not need this crate: generate `graph.bin` as a one-off build artifact, then embed it using `circom-witness-rs`.
 
+The builder keeps statically traceable witness work in the optimized graph and embeds portable
+Circom IR for input-dependent function control flow or array indexes. Dynamic local template
+branches are lowered to arithmetic selects.
+
 ```shell
 cargo run --release -p circom-witness-graph-builder -- circuit.circom graph.bin
 ```
 
 An optional third and subsequent argument supplies Circom library search paths.
+Pass `--O1` before the circuit when its reference R1CS/WTNS was compiled with O1; O2 remains the
+default.

--- a/graph-builder/src/lib.rs
+++ b/graph-builder/src/lib.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use std::{
-    env,
+    collections::{HashMap, HashSet},
+    env, fmt,
     path::{Path, PathBuf},
 };
 
@@ -20,7 +21,8 @@ use ruint::aliases::U256;
 
 use circom_witness_rs::{
     graph::{self, Node, Operation},
-    serialize_graph, HashSignalInfo, M,
+    runtime::{RuntimeExpression, RuntimeFunction, RuntimeOperation, RuntimeStatement},
+    serialize_graph_with_runtime, HashSignalInfo, M,
 };
 
 const CIRCOM_VERSION: &str = "2.2.2";
@@ -30,7 +32,19 @@ struct GraphBuilder {
     nodes: Vec<Node>,
     values: Vec<U256>,
     constant: Vec<bool>,
+    next_runtime_call: usize,
 }
+
+#[derive(Debug)]
+struct NeedsRuntime;
+
+impl fmt::Display for NeedsRuntime {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("Circom control flow or an array index depends on an input signal")
+    }
+}
+
+impl std::error::Error for NeedsRuntime {}
 
 impl GraphBuilder {
     fn push(&mut self, node: Node, value: U256, constant: bool) -> usize {
@@ -50,8 +64,12 @@ impl GraphBuilder {
     }
 
     fn op(&mut self, operation: Operation, a: usize, b: usize) -> usize {
-        let value = operation.eval(self.values[a], self.values[b]);
         let constant = self.constant[a] && self.constant[b];
+        let value = if constant {
+            operation.eval(self.values[a], self.values[b])
+        } else {
+            rand::thread_rng().gen::<U256>() % M
+        };
         self.push(Node::Op(operation, a, b), value, constant)
     }
 
@@ -60,11 +78,39 @@ impl GraphBuilder {
         self.push(Node::BBF(name, params), value, false)
     }
 
+    fn runtime_call(
+        &mut self,
+        function: usize,
+        params: Vec<usize>,
+        arena_size: usize,
+        output_count: usize,
+    ) -> Vec<usize> {
+        let call = self.next_runtime_call;
+        self.next_runtime_call += 1;
+        (0..output_count)
+            .map(|output| {
+                let value = rand::thread_rng().gen::<U256>() % M;
+                self.push(
+                    Node::RuntimeCall {
+                        function,
+                        call,
+                        output,
+                        output_count,
+                        arena_size,
+                        parameters: params.clone(),
+                    },
+                    value,
+                    false,
+                )
+            })
+            .collect()
+    }
+
     fn constant_value(&self, node: usize) -> Result<U256> {
         if self.constant[node] {
             Ok(self.values[node])
         } else {
-            bail!("Circom control flow or an array index depends on an input signal")
+            Err(NeedsRuntime.into())
         }
     }
 }
@@ -81,6 +127,7 @@ struct Component {
 struct Frame {
     component: usize,
     variables: Vec<Option<usize>>,
+    is_function: bool,
 }
 
 enum Eval {
@@ -123,12 +170,18 @@ enum Flow {
     Return(Vec<usize>),
 }
 
+type TemplateBranchSide = (Flow, Vec<Option<usize>>, HashMap<usize, Option<usize>>);
+
 struct Interpreter<'a> {
     circuit: &'a Circuit,
     graph: GraphBuilder,
     constants: Vec<usize>,
     signals: Vec<Option<usize>>,
     components: Vec<Option<Component>>,
+    runtime_functions: Vec<Option<RuntimeFunction>>,
+    runtime_function_ids: HashMap<(String, usize), usize>,
+    signal_undos: Vec<HashMap<usize, Option<usize>>>,
+    zero: usize,
 }
 
 impl<'a> Interpreter<'a> {
@@ -142,7 +195,8 @@ impl<'a> Interpreter<'a> {
         }
 
         let mut graph = GraphBuilder::default();
-        let mut signals = vec![None; producer.total_number_of_signals];
+        let zero = graph.constant(U256::ZERO);
+        let mut signals = vec![Some(zero); producer.total_number_of_signals];
         signals[0] = Some(graph.constant(U256::ONE));
 
         let main_input_start = producer.get_number_of_main_outputs();
@@ -167,10 +221,14 @@ impl<'a> Interpreter<'a> {
             constants,
             signals,
             components: vec![None; producer.number_of_components],
+            runtime_functions: Vec::new(),
+            runtime_function_ids: HashMap::new(),
+            signal_undos: Vec::new(),
+            zero,
         })
     }
 
-    fn build(mut self) -> Result<(Vec<Node>, Vec<usize>)> {
+    fn build(mut self) -> Result<(Vec<Node>, Vec<usize>, Vec<RuntimeFunction>)> {
         let main_template = self
             .circuit
             .templates
@@ -196,7 +254,15 @@ impl<'a> Interpreter<'a> {
                     .ok_or_else(|| eyre!("witness signal {signal} was not assigned by Circom"))
             })
             .collect::<Result<Vec<_>>>()?;
-        Ok((self.graph.nodes, outputs))
+        let runtime_functions = self
+            .runtime_functions
+            .into_iter()
+            .enumerate()
+            .map(|(index, function)| {
+                function.ok_or_else(|| eyre!("runtime Circom function {index} was not compiled"))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok((self.graph.nodes, outputs, runtime_functions))
     }
 
     fn run_template(&mut self, component_id: usize) -> Result<()> {
@@ -210,9 +276,17 @@ impl<'a> Interpreter<'a> {
         let template = circuit.get_template(component.template_id);
         let mut frame = Frame {
             component: component_id,
-            variables: vec![None; template.var_stack_depth],
+            variables: vec![Some(self.zero); template.var_stack_depth],
+            is_function: false,
         };
-        match self.execute_list(&template.body, &mut frame)? {
+        match self
+            .execute_list(&template.body, &mut frame)
+            .wrap_err_with(|| {
+                format!(
+                    "while symbolically executing Circom template {} (component {component_id})",
+                    template.header
+                )
+            })? {
             Flow::Continue => Ok(()),
             Flow::Return(_) => bail!("Circom template {} returned a value", template.header),
         }
@@ -232,7 +306,7 @@ impl<'a> Interpreter<'a> {
             .iter()
             .find(|function| function.header == symbol)
             .ok_or_else(|| eyre!("Circom function {symbol} was not found"))?;
-        let mut variables = vec![None; arena_size.max(function.max_number_of_vars)];
+        let mut variables = vec![Some(self.zero); arena_size.max(function.max_number_of_vars)];
         if arguments.len() > variables.len() {
             bail!("arguments for Circom function {symbol} exceed its variable arena");
         }
@@ -242,13 +316,47 @@ impl<'a> Interpreter<'a> {
         let mut frame = Frame {
             component,
             variables,
+            is_function: true,
         };
-        match self.execute_list(&function.body, &mut frame)? {
+        match self
+            .execute_list(&function.body, &mut frame)
+            .wrap_err_with(|| format!("while symbolically executing Circom function {symbol}"))?
+        {
             Flow::Return(mut values) => {
                 values.truncate(result_size);
                 Ok(values)
             }
             Flow::Continue => bail!("Circom function {symbol} did not return a value"),
+        }
+    }
+
+    fn execute_function_or_runtime(
+        &mut self,
+        symbol: &str,
+        arguments: Vec<usize>,
+        arena_size: usize,
+        component: usize,
+        result_size: usize,
+    ) -> Result<Vec<usize>> {
+        let checkpoint = self.graph.nodes.len();
+        match self.execute_function(
+            symbol,
+            arguments.clone(),
+            arena_size,
+            component,
+            result_size,
+        ) {
+            Ok(values) => Ok(values),
+            Err(error) if error.downcast_ref::<NeedsRuntime>().is_some() => {
+                self.graph.nodes.truncate(checkpoint);
+                self.graph.values.truncate(checkpoint);
+                self.graph.constant.truncate(checkpoint);
+                let function = self.compile_runtime_function(symbol, component)?;
+                Ok(self
+                    .graph
+                    .runtime_call(function, arguments, arena_size, result_size))
+            }
+            Err(error) => Err(error),
         }
     }
 
@@ -260,14 +368,25 @@ impl<'a> Interpreter<'a> {
                     self.execute_call(call, frame)?;
                 }
                 Instruction::Branch(branch) => {
-                    let condition = self.eval_condition(branch.cond.as_ref(), frame)?;
-                    let body = if condition {
-                        &branch.if_branch
+                    let condition = self.eval_condition_node(branch.cond.as_ref(), frame)?;
+                    if self.graph.constant[condition] {
+                        let body = if self.graph.values[condition] != U256::ZERO {
+                            &branch.if_branch
+                        } else {
+                            &branch.else_branch
+                        };
+                        if let Flow::Return(values) = self.execute_list(body, frame)? {
+                            return Ok(Flow::Return(values));
+                        }
+                    } else if frame.is_function {
+                        return Err(NeedsRuntime.into());
                     } else {
-                        &branch.else_branch
-                    };
-                    if let Flow::Return(values) = self.execute_list(body, frame)? {
-                        return Ok(Flow::Return(values));
+                        self.execute_dynamic_template_branch(
+                            condition,
+                            &branch.if_branch,
+                            &branch.else_branch,
+                            frame,
+                        )?;
                     }
                 }
                 Instruction::Loop(loop_bucket) => {
@@ -435,7 +554,7 @@ impl<'a> Interpreter<'a> {
                 let node = if is_black_box {
                     self.graph.black_box(call.symbol.clone(), arguments)
                 } else {
-                    let values = self.execute_function(
+                    let values = self.execute_function_or_runtime(
                         &call.symbol,
                         arguments,
                         call.arena_size,
@@ -460,7 +579,7 @@ impl<'a> Interpreter<'a> {
                     }
                     vec![self.graph.black_box(call.symbol.clone(), arguments)]
                 } else {
-                    self.execute_function(
+                    self.execute_function_or_runtime(
                         &call.symbol,
                         arguments,
                         call.arena_size,
@@ -685,6 +804,14 @@ impl<'a> Interpreter<'a> {
     }
 
     fn write_place(&mut self, place: &Place, values: &[usize], frame: &mut Frame) -> Result<()> {
+        if matches!(place.memory, Memory::Signals) {
+            for offset in 0..values.len() {
+                let index = place.offset + offset;
+                for undo in &mut self.signal_undos {
+                    undo.entry(index).or_insert(self.signals[index]);
+                }
+            }
+        }
         let memory = match place.memory {
             Memory::Variables => &mut frame.variables,
             Memory::Signals => &mut self.signals,
@@ -730,12 +857,311 @@ impl<'a> Interpreter<'a> {
         }
     }
 
+    fn compile_runtime_function(&mut self, symbol: &str, component: usize) -> Result<usize> {
+        let template_id = self.component(component)?.template_id;
+        let key = (symbol.to_owned(), template_id);
+        if let Some(&function) = self.runtime_function_ids.get(&key) {
+            return Ok(function);
+        }
+        let function = self
+            .circuit
+            .functions
+            .iter()
+            .find(|function| function.header == symbol)
+            .ok_or_else(|| eyre!("Circom function {symbol} was not found"))?;
+        let name = function.header.clone();
+        let variable_count = function.max_number_of_vars;
+        let body = function.body.clone();
+
+        let id = self.runtime_functions.len();
+        self.runtime_functions.push(None);
+        self.runtime_function_ids.insert(key, id);
+        let body = self.translate_runtime_list(&body, component)?;
+        self.runtime_functions[id] = Some(RuntimeFunction {
+            name,
+            variable_count,
+            body,
+        });
+        Ok(id)
+    }
+
+    fn translate_runtime_list(
+        &mut self,
+        body: &InstructionList,
+        component: usize,
+    ) -> Result<Vec<RuntimeStatement>> {
+        let mut translated = Vec::new();
+        for instruction in body {
+            match instruction.as_ref() {
+                Instruction::Store(store) => {
+                    if !matches!(store.dest_address_type, AddressType::Variable)
+                        || store.src_address_type.is_some()
+                    {
+                        bail!("runtime Circom functions may only access local variables")
+                    }
+                    let destination_size = self.resolve_size(&store.context, Some(component))?;
+                    let source_size = self.resolve_size(&store.src_context, Some(component))?;
+                    translated.push(RuntimeStatement::Store {
+                        offset: self.translate_runtime_location(&store.dest, component)?,
+                        size: destination_size.min(source_size),
+                        value: self.translate_runtime_expression(store.src.as_ref(), component)?,
+                    });
+                }
+                Instruction::Call(call) => match &call.return_info {
+                    ReturnType::Intermediate { .. } => translated.push(RuntimeStatement::Call(
+                        self.translate_runtime_call(call, component, 1)?,
+                    )),
+                    ReturnType::Final(data) => {
+                        if !matches!(data.dest_address_type, AddressType::Variable) {
+                            bail!("runtime Circom functions may only store local call results")
+                        }
+                        let size = self.resolve_size(&data.context, Some(component))?;
+                        translated.push(RuntimeStatement::Store {
+                            offset: self.translate_runtime_location(&data.dest, component)?,
+                            size,
+                            value: self.translate_runtime_call(call, component, size)?,
+                        });
+                    }
+                },
+                Instruction::Branch(branch) => translated.push(RuntimeStatement::Branch {
+                    condition: self
+                        .translate_runtime_expression(branch.cond.as_ref(), component)?,
+                    if_branch: self.translate_runtime_list(&branch.if_branch, component)?,
+                    else_branch: self.translate_runtime_list(&branch.else_branch, component)?,
+                }),
+                Instruction::Loop(loop_bucket) => translated.push(RuntimeStatement::Loop {
+                    condition: self.translate_runtime_expression(
+                        loop_bucket.continue_condition.as_ref(),
+                        component,
+                    )?,
+                    body: self.translate_runtime_list(&loop_bucket.body, component)?,
+                }),
+                Instruction::Return(return_bucket) => translated.push(RuntimeStatement::Return {
+                    value: self
+                        .translate_runtime_expression(return_bucket.value.as_ref(), component)?,
+                    size: return_bucket.with_size,
+                }),
+                Instruction::Value(_) | Instruction::Load(_) | Instruction::Compute(_) => {
+                    translated.push(RuntimeStatement::Call(
+                        self.translate_runtime_expression(instruction.as_ref(), component)?,
+                    ));
+                }
+                Instruction::Assert(_) | Instruction::Log(_) => {}
+                Instruction::CreateCmp(_) => {
+                    bail!("runtime Circom functions cannot create components")
+                }
+            }
+        }
+        Ok(translated)
+    }
+
+    fn translate_runtime_expression(
+        &mut self,
+        instruction: &Instruction,
+        component: usize,
+    ) -> Result<RuntimeExpression> {
+        Ok(match instruction {
+            Instruction::Value(value) => match value.parse_as {
+                ValueType::U32 => RuntimeExpression::Address(value.value),
+                ValueType::BigInt => {
+                    RuntimeExpression::Field(self.graph.values[self.constants[value.value]])
+                }
+            },
+            Instruction::Load(load) => {
+                if !matches!(load.address_type, AddressType::Variable) {
+                    bail!("runtime Circom functions may only load local variables")
+                }
+                RuntimeExpression::Load {
+                    offset: Box::new(self.translate_runtime_location(&load.src, component)?),
+                    size: self.resolve_size(&load.context, Some(component))?,
+                }
+            }
+            Instruction::Compute(compute) => {
+                let operation = match &compute.op {
+                    OperatorType::AddAddress => RuntimeOperation::AddAddress,
+                    OperatorType::MulAddress => RuntimeOperation::MulAddress,
+                    OperatorType::ToAddress => RuntimeOperation::ToAddress,
+                    OperatorType::Eq(size) => {
+                        RuntimeOperation::Equal(self.resolve_size_option(size, Some(component))?)
+                    }
+                    operation => RuntimeOperation::Field(operation_from_circom(operation)?),
+                };
+                RuntimeExpression::Compute {
+                    operation,
+                    operands: compute
+                        .stack
+                        .iter()
+                        .map(|operand| {
+                            self.translate_runtime_expression(operand.as_ref(), component)
+                        })
+                        .collect::<Result<Vec<_>>>()?,
+                }
+            }
+            Instruction::Call(call) => {
+                let ReturnType::Intermediate { .. } = call.return_info else {
+                    bail!("a final Circom call cannot be a runtime expression")
+                };
+                self.translate_runtime_call(call, component, 1)?
+            }
+            _ => bail!("Circom statement cannot be a runtime expression"),
+        })
+    }
+
+    fn translate_runtime_call(
+        &mut self,
+        call: &CallBucket,
+        component: usize,
+        result_size: usize,
+    ) -> Result<RuntimeExpression> {
+        let function = self.compile_runtime_function(&call.symbol, component)?;
+        let mut arguments = Vec::with_capacity(call.arguments.len());
+        for (argument, context) in call.arguments.iter().zip(&call.argument_types) {
+            arguments.push((
+                self.translate_runtime_expression(argument.as_ref(), component)?,
+                self.resolve_size(context, Some(component))?,
+            ));
+        }
+        Ok(RuntimeExpression::Call {
+            function,
+            arena_size: call.arena_size,
+            result_size,
+            arguments,
+        })
+    }
+
+    fn translate_runtime_location(
+        &mut self,
+        location: &LocationRule,
+        component: usize,
+    ) -> Result<RuntimeExpression> {
+        match location {
+            LocationRule::Indexed { location, .. } => {
+                self.translate_runtime_expression(location.as_ref(), component)
+            }
+            LocationRule::Mapped { .. } => {
+                bail!("runtime Circom functions cannot use mapped component locations")
+            }
+        }
+    }
+
+    fn execute_dynamic_template_branch(
+        &mut self,
+        condition: usize,
+        if_branch: &InstructionList,
+        else_branch: &InstructionList,
+        frame: &mut Frame,
+    ) -> Result<()> {
+        if !branch_has_local_effects(if_branch) || !branch_has_local_effects(else_branch) {
+            bail!("input-dependent Circom template branch has component side effects")
+        }
+
+        let base_variables = frame.variables.clone();
+        let (if_flow, if_variables, if_signals) =
+            self.execute_template_branch_side(if_branch, frame)?;
+        frame.variables.clone_from(&base_variables);
+        let (else_flow, else_variables, else_signals) =
+            self.execute_template_branch_side(else_branch, frame)?;
+        if !matches!((if_flow, else_flow), (Flow::Continue, Flow::Continue)) {
+            bail!("input-dependent Circom template branch cannot return a value")
+        }
+
+        for index in 0..frame.variables.len() {
+            frame.variables[index] = self.merge_optional_nodes(
+                condition,
+                if_variables[index],
+                else_variables[index],
+                "variable",
+                index,
+            )?;
+        }
+
+        let signal_indexes = if_signals
+            .keys()
+            .chain(else_signals.keys())
+            .copied()
+            .collect::<HashSet<_>>();
+        for index in signal_indexes {
+            let base = self.signals[index];
+            let if_value = if_signals.get(&index).copied().unwrap_or(base);
+            let else_value = else_signals.get(&index).copied().unwrap_or(base);
+            let merged =
+                self.merge_optional_nodes(condition, if_value, else_value, "signal", index)?;
+            self.set_signal(index, merged);
+        }
+        Ok(())
+    }
+
+    fn execute_template_branch_side(
+        &mut self,
+        body: &InstructionList,
+        frame: &mut Frame,
+    ) -> Result<TemplateBranchSide> {
+        let graph_start = self.graph.nodes.len();
+        self.signal_undos.push(HashMap::new());
+        let result = self.execute_list(body, frame);
+        for node in &mut self.graph.nodes[graph_start..] {
+            if let Node::Op(operation, _, _) = node {
+                if *operation == Operation::Div {
+                    *operation = Operation::SafeDiv;
+                }
+            }
+        }
+        let undo = self.signal_undos.pop().unwrap();
+        let values = undo
+            .keys()
+            .map(|&index| (index, self.signals[index]))
+            .collect::<HashMap<_, _>>();
+        for (&index, &original) in &undo {
+            self.signals[index] = original;
+        }
+        let flow = result?;
+        Ok((flow, frame.variables.clone(), values))
+    }
+
+    fn merge_optional_nodes(
+        &mut self,
+        condition: usize,
+        if_value: Option<usize>,
+        else_value: Option<usize>,
+        kind: &str,
+        index: usize,
+    ) -> Result<Option<usize>> {
+        match (if_value, else_value) {
+            (None, None) => Ok(None),
+            (Some(if_value), Some(else_value)) if if_value == else_value => Ok(Some(if_value)),
+            (Some(if_value), Some(else_value)) => {
+                let zero = self.graph.constant(U256::ZERO);
+                let condition = self.graph.op(Operation::Neq, condition, zero);
+                let difference = self.graph.op(Operation::Sub, if_value, else_value);
+                let selected = self.graph.op(Operation::Mul, condition, difference);
+                Ok(Some(self.graph.op(Operation::Add, else_value, selected)))
+            }
+            _ => bail!("input-dependent Circom branch initializes {kind} {index} on only one path"),
+        }
+    }
+
+    fn set_signal(&mut self, index: usize, value: Option<usize>) {
+        for undo in &mut self.signal_undos {
+            undo.entry(index).or_insert(self.signals[index]);
+        }
+        self.signals[index] = value;
+    }
+
     fn eval_condition(&mut self, instruction: &Instruction, frame: &mut Frame) -> Result<bool> {
-        let (nodes, _) = self.eval(instruction, frame)?.values()?;
-        let node = *nodes
-            .first()
-            .ok_or_else(|| eyre!("Circom condition is empty"))?;
+        let node = self.eval_condition_node(instruction, frame)?;
         Ok(self.graph.constant_value(node)? != U256::ZERO)
+    }
+
+    fn eval_condition_node(
+        &mut self,
+        instruction: &Instruction,
+        frame: &mut Frame,
+    ) -> Result<usize> {
+        let (nodes, _) = self.eval(instruction, frame)?.values()?;
+        nodes
+            .first()
+            .copied()
+            .ok_or_else(|| eyre!("Circom condition is empty"))
     }
 
     fn update_subcomponent_after_write(
@@ -790,6 +1216,33 @@ impl<'a> Interpreter<'a> {
     }
 }
 
+fn branch_has_local_effects(body: &InstructionList) -> bool {
+    body.iter().all(|instruction| match instruction.as_ref() {
+        Instruction::Store(store) => matches!(
+            store.dest_address_type,
+            AddressType::Variable | AddressType::Signal
+        ),
+        Instruction::Call(call) => match &call.return_info {
+            ReturnType::Intermediate { .. } => true,
+            ReturnType::Final(data) => matches!(
+                data.dest_address_type,
+                AddressType::Variable | AddressType::Signal
+            ),
+        },
+        Instruction::Branch(branch) => {
+            branch_has_local_effects(&branch.if_branch)
+                && branch_has_local_effects(&branch.else_branch)
+        }
+        Instruction::Loop(_) | Instruction::CreateCmp(_) => false,
+        Instruction::Value(_)
+        | Instruction::Load(_)
+        | Instruction::Compute(_)
+        | Instruction::Return(_)
+        | Instruction::Assert(_)
+        | Instruction::Log(_) => true,
+    })
+}
+
 fn operation_from_circom(operation: &OperatorType) -> Result<Operation> {
     use OperatorType::*;
     Ok(match operation {
@@ -836,7 +1289,11 @@ fn parse_field_constant(value: &str) -> Result<U256> {
     }
 }
 
-fn compile_circuit(circuit_path: &Path, library_paths: &[PathBuf]) -> Result<Circuit> {
+fn compile_circuit(
+    circuit_path: &Path,
+    library_paths: &[PathBuf],
+    use_o1: bool,
+) -> Result<Circuit> {
     let prime = M
         .to_string()
         .parse::<circom_compiler::num_bigint::BigInt>()
@@ -859,10 +1316,10 @@ fn compile_circuit(circuit_path: &Path, library_paths: &[PathBuf]) -> Result<Cir
     let (_, vcp) = build_circuit(
         program,
         BuildConfig {
-            no_rounds: usize::MAX,
+            no_rounds: if use_o1 { 0 } else { usize::MAX },
             flag_json_sub: false,
             json_substitutions: String::new(),
-            flag_s: false,
+            flag_s: use_o1,
             flag_f: false,
             flag_p: false,
             flag_verbose: false,
@@ -901,8 +1358,17 @@ pub fn generate_witness_graph_from_file(
     circuit_path: impl AsRef<Path>,
     library_paths: &[PathBuf],
 ) -> Result<Vec<u8>> {
+    generate_witness_graph_from_file_with_optimization(circuit_path, library_paths, false)
+}
+
+/// Compile a Circom circuit using either its O1 or O2 witness-to-signal mapping.
+pub fn generate_witness_graph_from_file_with_optimization(
+    circuit_path: impl AsRef<Path>,
+    library_paths: &[PathBuf],
+    use_o1: bool,
+) -> Result<Vec<u8>> {
     let circuit_path = circuit_path.as_ref();
-    let circuit = compile_circuit(circuit_path, library_paths)?;
+    let circuit = compile_circuit(circuit_path, library_paths, use_o1)?;
     let input_map = circuit
         .c_producer
         .main_input_list
@@ -915,12 +1381,12 @@ pub fn generate_witness_graph_from_file(
         .collect::<Vec<_>>();
 
     let started = std::time::Instant::now();
-    let (mut nodes, mut signals) = Interpreter::new(&circuit)?.build()?;
+    let (mut nodes, mut signals, runtime_functions) = Interpreter::new(&circuit)?.build()?;
     eprintln!("Symbolic execution took: {:?}", started.elapsed());
     eprintln!("Graph with {} nodes", nodes.len());
     graph::optimize(&mut nodes, &mut signals);
 
-    let bytes = serialize_graph(nodes, signals, input_map)?;
+    let bytes = serialize_graph_with_runtime(nodes, signals, input_map, runtime_functions)?;
     eprintln!("Graph size: {} bytes", bytes.len());
     Ok(bytes)
 }
@@ -935,7 +1401,8 @@ pub fn generate_witness_graph() -> Result<Vec<u8>> {
         .map(PathBuf::from)
         .into_iter()
         .collect::<Vec<_>>();
-    generate_witness_graph_from_file(&circuit_path, &library_paths)
+    let use_o1 = env::var_os("CIRCOM_OPTIMIZATION").is_some_and(|value| value == "O1");
+    generate_witness_graph_from_file_with_optimization(&circuit_path, &library_paths, use_o1)
 }
 
 /// Compile the selected circuit and write its optimized graph to `graph.bin`.

--- a/graph-builder/src/main.rs
+++ b/graph-builder/src/main.rs
@@ -2,11 +2,21 @@
 
 use std::{env, path::PathBuf};
 
-use circom_witness_graph_builder::generate_witness_graph_from_file;
+use circom_witness_graph_builder::generate_witness_graph_from_file_with_optimization;
 use eyre::{eyre, Context as _};
 
 fn main() -> eyre::Result<()> {
-    let mut arguments = env::args_os().skip(1);
+    let mut arguments = env::args_os().skip(1).collect::<Vec<_>>();
+    let use_o1 = if arguments.first().is_some_and(|argument| argument == "--O1") {
+        arguments.remove(0);
+        true
+    } else {
+        if arguments.first().is_some_and(|argument| argument == "--O2") {
+            arguments.remove(0);
+        }
+        false
+    };
+    let mut arguments = arguments.into_iter();
     let circuit = arguments.next().map(PathBuf::from).ok_or_else(|| {
         eyre!("usage: circom-witness-graph-builder <circuit> [output] [library paths...]")
     })?;
@@ -16,7 +26,8 @@ fn main() -> eyre::Result<()> {
         .unwrap_or_else(|| PathBuf::from("graph.bin"));
     let library_paths = arguments.map(PathBuf::from).collect::<Vec<_>>();
 
-    let graph = generate_witness_graph_from_file(&circuit, &library_paths)?;
+    let graph =
+        generate_witness_graph_from_file_with_optimization(&circuit, &library_paths, use_o1)?;
     std::fs::write(&output, graph)
         .wrap_err_with(|| format!("failed to write graph to {}", output.display()))?;
     Ok(())

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -58,6 +58,8 @@ pub enum Operation {
     Bxor,
     Bnot,
     Lnot,
+    /// Division used while lowering eager select branches; zero maps to zero on the unselected path.
+    SafeDiv,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -68,6 +70,14 @@ pub enum Node {
     MontConstant(Fr),
     Op(Operation, usize, usize),
     BBF(String, Vec<usize>),
+    RuntimeCall {
+        function: usize,
+        call: usize,
+        output: usize,
+        output_count: usize,
+        arena_size: usize,
+        parameters: Vec<usize>,
+    },
 }
 
 #[derive(Debug, Default, Clone)]
@@ -108,6 +118,13 @@ pub(crate) fn prepare_evaluation(
                 }
             }
             Node::BBF(_, parameters) => {
+                let mut depth = 0;
+                for parameter in parameters {
+                    depth = depth.max(referenced_depth(*parameter)?);
+                }
+                depth
+            }
+            Node::RuntimeCall { parameters, .. } => {
                 let mut depth = 0;
                 for parameter in parameters {
                     depth = depth.max(referenced_depth(*parameter)?);
@@ -160,6 +177,11 @@ pub(crate) fn prepare_evaluation(
                 *right = renumber[*right];
             }
             Node::BBF(_, parameters) => {
+                for parameter in parameters {
+                    *parameter = renumber[*parameter];
+                }
+            }
+            Node::RuntimeCall { parameters, .. } => {
                 for parameter in parameters {
                     *parameter = renumber[*parameter];
                 }
@@ -220,6 +242,10 @@ impl Operation {
             Neg => (M - a) % M,
             Inv => a.inv_mod(M).unwrap(),
             Div => a.mul_mod(b.inv_mod(M).unwrap(), M),
+            SafeDiv => b
+                .inv_mod(M)
+                .map(|inverse| a.mul_mod(inverse, M))
+                .unwrap_or(U256::ZERO),
             Mod => a.reduce_mod(b),
             Pow => a.pow_mod(b, M),
             IDiv => a / b,
@@ -236,6 +262,13 @@ impl Operation {
             Eq => (a == b).into(),
             Neg => -a,
             Div => a / b,
+            SafeDiv => {
+                if b == Fr::from(0_u64) {
+                    Fr::from(0_u64)
+                } else {
+                    a / b
+                }
+            }
             IDiv => {
                 let a: BigUint = a.into();
                 let b: BigUint = b.into();
@@ -294,9 +327,15 @@ fn shift_right(a: U256, amount: U256) -> U256 {
 /// All references must be backwards.
 fn assert_valid(nodes: &[Node]) {
     for (i, node) in nodes.iter().enumerate() {
-        if let Node::Op(_, a, b) = node {
-            assert!(*a < i);
-            assert!(*b < i);
+        match node {
+            Node::Op(_, a, b) => {
+                assert!(*a < i);
+                assert!(*b < i);
+            }
+            Node::BBF(_, parameters) | Node::RuntimeCall { parameters, .. } => {
+                assert!(parameters.iter().all(|parameter| *parameter < i));
+            }
+            Node::Input(_) | Node::Constant(_) | Node::MontConstant(_) => {}
         }
     }
 }
@@ -388,6 +427,9 @@ pub(crate) fn evaluate_with_plan(
                 } else {
                     bail!("no black box functions provided");
                 }
+            }
+            Node::RuntimeCall { .. } => {
+                bail!("runtime Circom calls require their serialized function table")
             }
         };
         values.push(value);
@@ -485,6 +527,11 @@ pub fn tree_shake(nodes: &mut Vec<Node>, outputs: &mut [usize]) {
                     used[param] = true;
                 }
             }
+            if let Node::RuntimeCall { parameters, .. } = &nodes[i] {
+                for &parameter in parameters {
+                    used[parameter] = true;
+                }
+            }
         }
     }
 
@@ -519,6 +566,11 @@ pub fn tree_shake(nodes: &mut Vec<Node>, outputs: &mut [usize]) {
                 *param = renumber[*param].unwrap();
             }
         }
+        if let Node::RuntimeCall { parameters, .. } = node {
+            for parameter in parameters {
+                *parameter = renumber[*parameter].unwrap();
+            }
+        }
     }
     for output in outputs.iter_mut() {
         *output = renumber[*output].unwrap();
@@ -536,7 +588,7 @@ fn random_eval(nodes: &mut [Node]) -> Vec<U256> {
     for node in nodes.iter() {
         use Operation::*;
         let value = match node {
-            Node::BBF(_, _) => rng.gen::<U256>() % M,
+            Node::BBF(_, _) | Node::RuntimeCall { .. } => rng.gen::<U256>() % M,
             // Constants evaluate to themselves
             Node::Constant(c) => *c,
 
@@ -590,6 +642,11 @@ pub fn value_numbering(nodes: &mut [Node], outputs: &mut [usize]) {
                 *p = renumber[*p];
             }
         }
+        if let Node::RuntimeCall { parameters, .. } = node {
+            for parameter in parameters {
+                *parameter = renumber[*parameter];
+            }
+        }
     }
     for output in outputs.iter_mut() {
         *output = renumber[*output];
@@ -630,6 +687,7 @@ pub fn montgomery_form(nodes: &mut [Node]) {
             Input(..) => (),
             Op(..) => (),
             BBF(..) => (),
+            RuntimeCall { .. } => (),
         }
     }
     eprintln!("Converted to Montgomery form");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod graph;
 mod program;
+#[doc(hidden)]
+pub mod runtime;
 
 use std::{
     collections::HashMap,
@@ -19,7 +21,8 @@ pub const M: U256 =
     uint!(21888242871839275222246405745257275088548364400416034343698204186575808495617_U256);
 
 const LEGACY_GRAPH_HEADER: &[u8; 8] = b"CWGR\x01DZ\0";
-const GRAPH_HEADER: &[u8; 8] = b"CWGR\x02FZ\0";
+const PREVIOUS_FUSED_GRAPH_HEADER: &[u8; 8] = b"CWGR\x02FZ\0";
+const GRAPH_HEADER: &[u8; 8] = b"CWGR\x03FZ\0";
 const GRAPH_MAGIC: &[u8; 4] = b"CWGR";
 const GRAPH_COMPRESSION_LEVEL: i32 = 19;
 
@@ -166,10 +169,21 @@ pub fn serialize_graph(
     signals: Vec<usize>,
     input_mapping: Vec<HashSignalInfo>,
 ) -> eyre::Result<Vec<u8>> {
+    serialize_graph_with_runtime(nodes, signals, input_mapping, Vec::new())
+}
+
+#[doc(hidden)]
+pub fn serialize_graph_with_runtime(
+    nodes: Vec<Node>,
+    signals: Vec<usize>,
+    input_mapping: Vec<HashSignalInfo>,
+    runtime_functions: Vec<runtime::RuntimeFunction>,
+) -> eyre::Result<Vec<u8>> {
     // Preserve the builder's topological order on disk. Division-depth reordering improves runtime
     // but measurably hurts compression on large graphs, so it is deliberately done only at load.
-    let encoded_program = program::compile(&nodes, &signals, &[])?.encode()?;
-    let postcard = postcard::to_stdvec(&(&encoded_program, &input_mapping))?;
+    let encoded_program =
+        program::compile(&nodes, &signals, &[], runtime_functions.clone())?.encode()?;
+    let postcard = postcard::to_stdvec(&(&encoded_program, &input_mapping, &runtime_functions))?;
     let compressed = zstd::stream::encode_all(postcard.as_slice(), GRAPH_COMPRESSION_LEVEL)
         .wrap_err("failed to compress witness graph")?;
     let mut encoded = Vec::with_capacity(GRAPH_HEADER.len() + compressed.len());
@@ -186,6 +200,11 @@ fn restore_absolute_references(nodes: &mut [Node], signals: &mut [usize]) -> eyr
                 *right = decode_backward_reference(index, *right)?;
             }
             Node::BBF(_, parameters) => {
+                for parameter in parameters {
+                    *parameter = decode_backward_reference(index, *parameter)?;
+                }
+            }
+            Node::RuntimeCall { parameters, .. } => {
                 for parameter in parameters {
                     *parameter = decode_backward_reference(index, *parameter)?;
                 }
@@ -219,6 +238,7 @@ pub fn init_graph(graph_bytes: &[u8]) -> eyre::Result<Graph> {
     #[derive(Clone, Copy)]
     enum Format {
         Fused,
+        PreviousFused,
         LegacyCompressed,
         LegacyRaw,
     }
@@ -229,6 +249,11 @@ pub fn init_graph(graph_bytes: &[u8]) -> eyre::Result<Graph> {
             .ok_or_else(|| eyre!("witness graph header is truncated"))?;
         if header == GRAPH_HEADER {
             (Format::Fused, &graph_bytes[GRAPH_HEADER.len()..])
+        } else if header == PREVIOUS_FUSED_GRAPH_HEADER {
+            (
+                Format::PreviousFused,
+                &graph_bytes[PREVIOUS_FUSED_GRAPH_HEADER.len()..],
+            )
         } else if header == LEGACY_GRAPH_HEADER {
             (
                 Format::LegacyCompressed,
@@ -250,10 +275,21 @@ pub fn init_graph(graph_bytes: &[u8]) -> eyre::Result<Graph> {
         decompressed.as_slice()
     };
 
-    if matches!(format, Format::Fused) {
-        let (encoded, input_mapping): (program::EncodedProgram, Vec<HashSignalInfo>) =
-            postcard::from_bytes(payload).wrap_err("failed to decode fused witness graph")?;
-        let program = program::Program::decode(encoded)?.prepare_evaluation()?;
+    if matches!(format, Format::Fused | Format::PreviousFused) {
+        let (encoded, input_mapping, runtime_functions) = if matches!(format, Format::Fused) {
+            let (encoded, input_mapping, runtime_functions): (
+                program::EncodedProgram,
+                Vec<HashSignalInfo>,
+                Vec<runtime::RuntimeFunction>,
+            ) = postcard::from_bytes(payload).wrap_err("failed to decode fused witness graph")?;
+            (encoded, input_mapping, runtime_functions)
+        } else {
+            let (encoded, input_mapping): (program::EncodedProgram, Vec<HashSignalInfo>) =
+                postcard::from_bytes(payload)
+                    .wrap_err("failed to decode previous fused witness graph")?;
+            (encoded, input_mapping, Vec::new())
+        };
+        let program = program::Program::decode(encoded, runtime_functions)?.prepare_evaluation()?;
         return Ok(Graph {
             compatibility: OnceLock::new(),
             input_mapping,
@@ -262,7 +298,7 @@ pub fn init_graph(graph_bytes: &[u8]) -> eyre::Result<Graph> {
     }
 
     let (mut nodes, mut signals, input_mapping) = match format {
-        Format::Fused => unreachable!(),
+        Format::Fused | Format::PreviousFused => unreachable!(),
         Format::LegacyCompressed => {
             let (mut nodes, mut signals, input_mapping): (
                 Vec<Node>,
@@ -278,7 +314,12 @@ pub fn init_graph(graph_bytes: &[u8]) -> eyre::Result<Graph> {
     };
 
     let evaluation_plan = graph::prepare_evaluation(&mut nodes, &mut signals)?;
-    let program = program::compile(&nodes, &signals, evaluation_plan.division_batches())?;
+    let program = program::compile(
+        &nodes,
+        &signals,
+        evaluation_plan.division_batches(),
+        Vec::new(),
+    )?;
 
     Ok(Graph {
         compatibility: OnceLock::from(CompatibilityGraph { nodes, signals }),
@@ -344,6 +385,7 @@ pub fn calculate_witness(
 mod tests {
     use super::*;
     use crate::graph::Operation;
+    use crate::runtime::{RuntimeExpression, RuntimeFunction, RuntimeStatement};
 
     fn graph_parts() -> (Vec<Node>, Vec<usize>, Vec<HashSignalInfo>) {
         let nodes = vec![
@@ -420,6 +462,11 @@ mod tests {
                         *parameter = encode_backward_reference(index, *parameter).unwrap();
                     }
                 }
+                Node::RuntimeCall { parameters, .. } => {
+                    for parameter in parameters {
+                        *parameter = encode_backward_reference(index, *parameter).unwrap();
+                    }
+                }
                 Node::Input(_) | Node::Constant(_) | Node::MontConstant(_) => {}
             }
         }
@@ -461,6 +508,39 @@ mod tests {
         assert_eq!(graph.evaluate(&inputs, None).unwrap(), expected);
         let mut evaluator = graph.evaluator(None).unwrap();
         assert_eq!(evaluator.evaluate(&inputs).unwrap(), expected);
+    }
+
+    #[test]
+    fn fused_graph_round_trips_runtime_ir_calls() {
+        let nodes = vec![
+            Node::Input(0),
+            Node::RuntimeCall {
+                function: 0,
+                call: 0,
+                output: 0,
+                output_count: 1,
+                arena_size: 1,
+                parameters: vec![0],
+            },
+        ];
+        let functions = vec![RuntimeFunction {
+            name: "identity".to_owned(),
+            variable_count: 1,
+            body: vec![RuntimeStatement::Return {
+                value: RuntimeExpression::Load {
+                    offset: Box::new(RuntimeExpression::Address(0)),
+                    size: 1,
+                },
+                size: 1,
+            }],
+        }];
+        let encoded = serialize_graph_with_runtime(nodes, vec![1], Vec::new(), functions).unwrap();
+        let graph = init_graph(&encoded).unwrap();
+
+        assert_eq!(
+            graph.evaluate(&[U256::from(7_u64)], None).unwrap(),
+            vec![U256::from(7_u64)]
+        );
     }
 
     #[test]

--- a/src/program.rs
+++ b/src/program.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     graph::{Node, Operation},
+    runtime::RuntimeFunction,
     BlackBoxFunction, M,
 };
 
@@ -26,6 +27,9 @@ pub(crate) struct Program {
     linear3: Vec<[(u32, u32); 3]>,
     linear4: Vec<[(u32, u32); 4]>,
     black_boxes: Vec<BlackBoxInstruction>,
+    runtime_functions: Vec<RuntimeFunction>,
+    runtime_calls: Vec<RuntimeCallInstruction>,
+    runtime_call_count: usize,
     outputs: Vec<usize>,
     division_batches: Vec<Range<usize>>,
     value_count: usize,
@@ -38,6 +42,9 @@ pub(crate) struct EvaluationWorkspace {
     inverses: Vec<Fr>,
     inversion_scratch: Vec<Fr>,
     black_box_parameters: Vec<Fr>,
+    runtime_parameters: Vec<Fr>,
+    runtime_results: Vec<Vec<Fr>>,
+    runtime_ready: Vec<bool>,
     outputs: Vec<U256>,
 }
 
@@ -65,11 +72,22 @@ enum Instruction {
     Linear3(u32),
     Linear4(u32),
     BlackBox(u32),
+    RuntimeCall(u32),
 }
 
 #[derive(Debug, Clone)]
 struct BlackBoxInstruction {
     name: String,
+    parameters: Vec<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RuntimeCallInstruction {
+    function: usize,
+    call: usize,
+    output: usize,
+    output_count: usize,
+    arena_size: usize,
     parameters: Vec<u32>,
 }
 
@@ -95,6 +113,14 @@ enum EncodedInstruction {
     Linear3([(usize, usize); 3]),
     Linear4([(usize, usize); 4]),
     BlackBox(String, Vec<usize>),
+    RuntimeCall {
+        function: usize,
+        call: usize,
+        output: usize,
+        output_count: usize,
+        arena_size: usize,
+        parameters: Vec<usize>,
+    },
 }
 
 #[derive(Default)]
@@ -128,6 +154,11 @@ fn validate_graph(nodes: &[Node], outputs: &[usize]) -> eyre::Result<()> {
                 check_reference(index, *right)?;
             }
             Node::BBF(_, parameters) => {
+                for &parameter in parameters {
+                    check_reference(index, parameter)?;
+                }
+            }
+            Node::RuntimeCall { parameters, .. } => {
                 for &parameter in parameters {
                     check_reference(index, parameter)?;
                 }
@@ -242,6 +273,11 @@ fn linear_specs(
                     sole_user[parameter] = Some(index);
                 }
             }
+            Node::RuntimeCall { parameters, .. } => {
+                for &parameter in parameters {
+                    sole_user[parameter] = Some(index);
+                }
+            }
             _ => {}
         }
     }
@@ -299,6 +335,7 @@ pub(crate) fn compile(
     nodes: &[Node],
     outputs: &[usize],
     division_node_batches: &[Range<usize>],
+    runtime_functions: Vec<RuntimeFunction>,
 ) -> eyre::Result<Program> {
     validate_graph(nodes, outputs)?;
 
@@ -312,6 +349,11 @@ pub(crate) fn compile(
                 }
             }
             Node::BBF(_, parameters) => {
+                for &parameter in parameters {
+                    uses[parameter] += 1;
+                }
+            }
+            Node::RuntimeCall { parameters, .. } => {
                 for &parameter in parameters {
                     uses[parameter] += 1;
                 }
@@ -390,6 +432,8 @@ pub(crate) fn compile(
     let mut linear3 = Vec::new();
     let mut linear4 = Vec::new();
     let mut black_boxes = Vec::new();
+    let mut runtime_calls = Vec::new();
+    let mut runtime_call_count = 0_usize;
     let mut node_to_value = vec![None; nodes.len()];
     let mut node_to_instruction = vec![None; nodes.len()];
     let mut value_count = 0_usize;
@@ -489,6 +533,34 @@ pub(crate) fn compile(
                         });
                         Instruction::BlackBox(index)
                     }
+                    Node::RuntimeCall {
+                        function,
+                        call,
+                        output,
+                        output_count,
+                        arena_size,
+                        parameters,
+                    } => {
+                        let index = narrow_id(runtime_calls.len(), "runtime-call ID")?;
+                        runtime_call_count = runtime_call_count.max(
+                            call.checked_add(1)
+                                .ok_or_else(|| eyre!("runtime-call ID overflowed"))?,
+                        );
+                        runtime_calls.push(RuntimeCallInstruction {
+                            function: *function,
+                            call: *call,
+                            output: *output,
+                            output_count: *output_count,
+                            arena_size: *arena_size,
+                            parameters: parameters
+                                .iter()
+                                .map(|parameter| {
+                                    narrow_id(node_to_value[*parameter].unwrap(), "value ID")
+                                })
+                                .collect::<eyre::Result<Vec<_>>>()?,
+                        });
+                        Instruction::RuntimeCall(index)
+                    }
                 }
             };
             node_to_value[node_index] = Some(value_count);
@@ -533,6 +605,9 @@ pub(crate) fn compile(
         linear3,
         linear4,
         black_boxes,
+        runtime_functions,
+        runtime_calls,
+        runtime_call_count,
         outputs,
         division_batches,
         value_count,
@@ -628,6 +703,13 @@ impl Program {
                     .try_fold(0_usize, |depth, &value| {
                         Ok::<_, eyre::Report>(depth.max(value_depth(value)?))
                     })?,
+                Instruction::RuntimeCall(runtime_call) => self.runtime_calls
+                    [*runtime_call as usize]
+                    .parameters
+                    .iter()
+                    .try_fold(0_usize, |depth, &value| {
+                        Ok::<_, eyre::Report>(depth.max(value_depth(value)?))
+                    })?,
             };
             max_depth = max_depth.max(depth);
             instruction_depths.push(depth);
@@ -708,6 +790,7 @@ impl Program {
         let mut linear3 = Vec::with_capacity(self.linear3.len());
         let mut linear4 = Vec::with_capacity(self.linear4.len());
         let mut black_boxes = Vec::with_capacity(self.black_boxes.len());
+        let mut runtime_calls = Vec::with_capacity(self.runtime_calls.len());
         for old_instruction in order {
             let instruction = match &self.instructions[old_instruction] {
                 Instruction::Input(input) => Instruction::Input(*input),
@@ -760,6 +843,19 @@ impl Program {
                     });
                     Instruction::BlackBox(index)
                 }
+                Instruction::RuntimeCall(runtime_call) => {
+                    let runtime_call = &self.runtime_calls[*runtime_call as usize];
+                    let index = narrow_id(runtime_calls.len(), "runtime-call ID")?;
+                    runtime_calls.push(RuntimeCallInstruction {
+                        parameters: runtime_call
+                            .parameters
+                            .iter()
+                            .map(|&value| remap_value(value))
+                            .collect::<eyre::Result<Vec<_>>>()?,
+                        ..runtime_call.clone()
+                    });
+                    Instruction::RuntimeCall(index)
+                }
             };
             instructions.push(instruction);
         }
@@ -768,6 +864,7 @@ impl Program {
         self.linear3 = linear3;
         self.linear4 = linear4;
         self.black_boxes = black_boxes;
+        self.runtime_calls = runtime_calls;
         self.outputs = self
             .outputs
             .into_iter()
@@ -815,12 +912,19 @@ impl Program {
             inverses,
             inversion_scratch,
             black_box_parameters,
+            runtime_parameters,
+            runtime_results,
+            runtime_ready,
             outputs,
         } = workspace;
         values.clear();
         values.reserve(self.value_count);
         inverses.clear();
         black_box_parameters.clear();
+        runtime_parameters.clear();
+        runtime_results.resize_with(self.runtime_call_count, Vec::new);
+        runtime_ready.resize(self.runtime_call_count, false);
+        runtime_ready.fill(false);
         outputs.clear();
         outputs.reserve(self.outputs.len());
         let mut batches = self.division_batches.iter().peekable();
@@ -934,6 +1038,27 @@ impl Program {
                     );
                     values.push(function(black_box_parameters));
                 }
+                Instruction::RuntimeCall(runtime_call) => {
+                    let runtime_call = &self.runtime_calls[*runtime_call as usize];
+                    if !runtime_ready[runtime_call.call] {
+                        runtime_parameters.clear();
+                        runtime_parameters.extend(
+                            runtime_call
+                                .parameters
+                                .iter()
+                                .map(|&value| values[value as usize]),
+                        );
+                        runtime_results[runtime_call.call] = crate::runtime::evaluate(
+                            &self.runtime_functions,
+                            runtime_call.function,
+                            runtime_parameters,
+                            runtime_call.arena_size,
+                            runtime_call.output_count,
+                        )?;
+                        runtime_ready[runtime_call.call] = true;
+                    }
+                    values.push(runtime_results[runtime_call.call][runtime_call.output]);
+                }
             }
             instruction_index += 1;
         }
@@ -1001,6 +1126,29 @@ impl Program {
                         )
                     })?;
                     for &parameter in &black_box.parameters {
+                        check_value(parameter as usize)?;
+                    }
+                }
+                Instruction::RuntimeCall(runtime_call) => {
+                    let runtime_call = self.runtime_calls.get(*runtime_call as usize).ok_or_else(|| {
+                        eyre!("program instruction {index} references missing runtime call {runtime_call}")
+                    })?;
+                    if runtime_call.function >= self.runtime_functions.len() {
+                        bail!(
+                            "runtime call references missing function {}",
+                            runtime_call.function
+                        );
+                    }
+                    if runtime_call.call >= self.runtime_call_count {
+                        bail!("runtime-call ID {} is out of bounds", runtime_call.call);
+                    }
+                    if runtime_call.output >= runtime_call.output_count {
+                        bail!(
+                            "runtime-call output {} is out of bounds",
+                            runtime_call.output
+                        );
+                    }
+                    for &parameter in &runtime_call.parameters {
                         check_value(parameter as usize)?;
                     }
                 }
@@ -1085,6 +1233,21 @@ impl Program {
                             .collect::<eyre::Result<Vec<_>>>()?,
                     )
                 }
+                Instruction::RuntimeCall(runtime_call) => {
+                    let runtime_call = &self.runtime_calls[*runtime_call as usize];
+                    EncodedInstruction::RuntimeCall {
+                        function: runtime_call.function,
+                        call: runtime_call.call,
+                        output: runtime_call.output,
+                        output_count: runtime_call.output_count,
+                        arena_size: runtime_call.arena_size,
+                        parameters: runtime_call
+                            .parameters
+                            .iter()
+                            .map(|&parameter| backward(parameter as usize))
+                            .collect::<eyre::Result<Vec<_>>>()?,
+                    }
+                }
             };
             instructions.push(instruction);
             next_value += if matches!(
@@ -1125,7 +1288,10 @@ impl Program {
         })
     }
 
-    pub(crate) fn decode(encoded: EncodedProgram) -> eyre::Result<Self> {
+    pub(crate) fn decode(
+        encoded: EncodedProgram,
+        runtime_functions: Vec<RuntimeFunction>,
+    ) -> eyre::Result<Self> {
         let coefficients = encoded
             .coefficients
             .into_iter()
@@ -1141,6 +1307,8 @@ impl Program {
         let mut linear3 = Vec::new();
         let mut linear4 = Vec::new();
         let mut black_boxes = Vec::new();
+        let mut runtime_calls = Vec::new();
+        let mut runtime_call_count = 0_usize;
         let mut next_value = 0_usize;
         let mut input_count = 0_usize;
         for encoded_instruction in encoded.instructions {
@@ -1241,6 +1409,32 @@ impl Program {
                     });
                     Instruction::BlackBox(index)
                 }
+                EncodedInstruction::RuntimeCall {
+                    function,
+                    call,
+                    output,
+                    output_count,
+                    arena_size,
+                    parameters,
+                } => {
+                    let index = narrow_id(runtime_calls.len(), "runtime-call ID")?;
+                    runtime_call_count = runtime_call_count.max(
+                        call.checked_add(1)
+                            .ok_or_else(|| eyre!("runtime-call ID overflowed"))?,
+                    );
+                    runtime_calls.push(RuntimeCallInstruction {
+                        function,
+                        call,
+                        output,
+                        output_count,
+                        arena_size,
+                        parameters: parameters
+                            .into_iter()
+                            .map(|parameter| narrow_id(absolute(parameter)?, "value ID"))
+                            .collect::<eyre::Result<Vec<_>>>()?,
+                    });
+                    Instruction::RuntimeCall(index)
+                }
             };
             next_value = next_value
                 .checked_add(if matches!(instruction, Instruction::Pow5(_)) {
@@ -1274,6 +1468,9 @@ impl Program {
             linear3,
             linear4,
             black_boxes,
+            runtime_functions,
+            runtime_calls,
+            runtime_call_count,
             outputs,
             division_batches: Vec::new(),
             value_count: next_value,
@@ -1385,6 +1582,24 @@ impl Program {
                         &mut nodes,
                     ));
                 }
+                Instruction::RuntimeCall(runtime_call) => {
+                    let runtime_call = &self.runtime_calls[*runtime_call as usize];
+                    value_nodes.push(push(
+                        Node::RuntimeCall {
+                            function: runtime_call.function,
+                            call: runtime_call.call,
+                            output: runtime_call.output,
+                            output_count: runtime_call.output_count,
+                            arena_size: runtime_call.arena_size,
+                            parameters: runtime_call
+                                .parameters
+                                .iter()
+                                .map(|&parameter| value_nodes[parameter as usize])
+                                .collect(),
+                        },
+                        &mut nodes,
+                    ));
+                }
             }
         }
         let outputs = self
@@ -1452,7 +1667,7 @@ mod tests {
             Node::Op(Operation::Mul, 10, 8),
         ];
         let outputs = vec![5, 6, 7, 8, 9, 10, 11];
-        let original = compile(&nodes, &outputs, &[]).unwrap();
+        let original = compile(&nodes, &outputs, &[], Vec::new()).unwrap();
         let prepared = original.clone().prepare_evaluation().unwrap();
         assert_eq!(prepared.instruction_count(), original.instruction_count());
         assert_eq!(prepared.division_batches.len(), 2);
@@ -1492,7 +1707,7 @@ mod tests {
             Node::Op(Operation::Mul, 7, 5),
         ];
         let outputs = vec![5, 6, 7, 8];
-        let program = compile(&nodes, &outputs, &[]).unwrap();
+        let program = compile(&nodes, &outputs, &[], Vec::new()).unwrap();
         assert!(program
             .instructions
             .iter()
@@ -1502,14 +1717,14 @@ mod tests {
             .iter()
             .any(|instruction| matches!(instruction, Instruction::Pow5(_))));
 
-        let decoded = Program::decode(program.encode().unwrap()).unwrap();
+        let decoded = Program::decode(program.encode().unwrap(), Vec::new()).unwrap();
         let inputs = [U256::from(3_u64), U256::from(2_u64)];
         assert_eq!(
             crate::graph::evaluate(&nodes, &inputs, &outputs, None).unwrap(),
             decoded.evaluate(&inputs, None).unwrap()
         );
         let (expanded, expanded_outputs) = decoded.to_nodes().unwrap();
-        let recompiled = compile(&expanded, &expanded_outputs, &[]).unwrap();
+        let recompiled = compile(&expanded, &expanded_outputs, &[], Vec::new()).unwrap();
         assert_eq!(recompiled.instructions.len(), decoded.instructions.len());
         assert_eq!(
             crate::graph::evaluate(&nodes, &inputs, &outputs, None).unwrap(),
@@ -1524,14 +1739,14 @@ mod tests {
             instructions: vec![EncodedInstruction::Square(0)],
             output_deltas: vec![0],
         };
-        assert!(Program::decode(invalid_reference).is_err());
+        assert!(Program::decode(invalid_reference, Vec::new()).is_err());
 
         let invalid_coefficient = EncodedProgram {
             coefficients: vec![M.to_le_bytes()],
             instructions: vec![EncodedInstruction::Constant(0)],
             output_deltas: vec![0],
         };
-        assert!(Program::decode(invalid_coefficient).is_err());
+        assert!(Program::decode(invalid_coefficient, Vec::new()).is_err());
     }
 
     #[test]
@@ -1546,7 +1761,7 @@ mod tests {
         ];
         let outputs = [5];
         let inputs = [U256::from(4_u64), U256::from(5_u64)];
-        let program = compile(&nodes, &outputs, &[]).unwrap();
+        let program = compile(&nodes, &outputs, &[], Vec::new()).unwrap();
         assert_eq!(
             program.evaluate(&inputs, None).unwrap(),
             crate::graph::evaluate(&nodes, &inputs, &outputs, None).unwrap()
@@ -1567,7 +1782,7 @@ mod tests {
         ];
         let outputs = [7];
         let inputs = [U256::from(4_u64), U256::from(5_u64)];
-        let program = compile(&nodes, &outputs, &[]).unwrap();
+        let program = compile(&nodes, &outputs, &[], Vec::new()).unwrap();
         assert_eq!(
             program.evaluate(&inputs, None).unwrap(),
             crate::graph::evaluate(&nodes, &inputs, &outputs, None).unwrap()
@@ -1582,9 +1797,9 @@ mod tests {
             nodes.push(Node::Op(Operation::Add, previous, 0));
         }
         let outputs = [nodes.len() - 1];
-        let program = compile(&nodes, &outputs, &[]).unwrap();
-        let decoded = Program::decode(program.encode().unwrap()).unwrap();
+        let program = compile(&nodes, &outputs, &[], Vec::new()).unwrap();
+        let decoded = Program::decode(program.encode().unwrap(), Vec::new()).unwrap();
         let (expanded, expanded_outputs) = decoded.to_nodes().unwrap();
-        compile(&expanded, &expanded_outputs, &[]).unwrap();
+        compile(&expanded, &expanded_outputs, &[], Vec::new()).unwrap();
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,456 @@
+//! Portable interpreter for the small parts of Circom witness code that cannot be represented by
+//! a static arithmetic graph (input-dependent branches, loops, or array indexes).
+
+use ark_bn254::Fr;
+use eyre::{bail, eyre};
+use num_bigint::BigUint;
+use ruint::aliases::U256;
+use serde::{Deserialize, Serialize};
+
+use crate::graph::Operation;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeFunction {
+    pub name: String,
+    pub variable_count: usize,
+    pub body: Vec<RuntimeStatement>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RuntimeStatement {
+    Store {
+        offset: RuntimeExpression,
+        size: usize,
+        value: RuntimeExpression,
+    },
+    Call(RuntimeExpression),
+    Branch {
+        condition: RuntimeExpression,
+        if_branch: Vec<RuntimeStatement>,
+        else_branch: Vec<RuntimeStatement>,
+    },
+    Loop {
+        condition: RuntimeExpression,
+        body: Vec<RuntimeStatement>,
+    },
+    Return {
+        value: RuntimeExpression,
+        size: usize,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RuntimeExpression {
+    Field(U256),
+    Address(usize),
+    Load {
+        offset: Box<RuntimeExpression>,
+        size: usize,
+    },
+    Compute {
+        operation: RuntimeOperation,
+        operands: Vec<RuntimeExpression>,
+    },
+    Call {
+        function: usize,
+        arena_size: usize,
+        result_size: usize,
+        arguments: Vec<(RuntimeExpression, usize)>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RuntimeOperation {
+    Field(Operation),
+    Equal(usize),
+    ToAddress,
+    AddAddress,
+    MulAddress,
+}
+
+enum Value {
+    Address(usize),
+    Fields(Vec<Fr>),
+}
+
+impl Value {
+    fn address(self) -> eyre::Result<usize> {
+        match self {
+            Self::Address(value) => Ok(value),
+            Self::Fields(_) => bail!("runtime Circom expression is not an address"),
+        }
+    }
+
+    fn fields(self) -> eyre::Result<Vec<Fr>> {
+        match self {
+            Self::Fields(values) => Ok(values),
+            Self::Address(_) => bail!("runtime Circom expression is not a field value"),
+        }
+    }
+}
+
+enum Flow {
+    Continue,
+    Return(Vec<Fr>),
+}
+
+struct Interpreter<'a> {
+    functions: &'a [RuntimeFunction],
+    steps_left: usize,
+}
+
+impl<'a> Interpreter<'a> {
+    fn step(&mut self) -> eyre::Result<()> {
+        self.steps_left = self
+            .steps_left
+            .checked_sub(1)
+            .ok_or_else(|| eyre!("runtime Circom instruction limit exceeded"))?;
+        Ok(())
+    }
+
+    fn call(
+        &mut self,
+        function: usize,
+        arguments: &[Fr],
+        arena_size: usize,
+        result_size: usize,
+    ) -> eyre::Result<Vec<Fr>> {
+        let function = self
+            .functions
+            .get(function)
+            .ok_or_else(|| eyre!("runtime Circom function {function} is missing"))?;
+        if function.name == "mod_inv" || function.name.starts_with("mod_inv_") {
+            return evaluate_mod_inv(arguments, result_size);
+        }
+        let mut variables = vec![Fr::from(0_u64); arena_size.max(function.variable_count)];
+        if arguments.len() > variables.len() {
+            bail!(
+                "arguments for runtime Circom function {} exceed its variable arena",
+                function.name
+            );
+        }
+        variables[..arguments.len()].copy_from_slice(arguments);
+        match self.execute_list(&function.body, &mut variables)? {
+            Flow::Return(mut values) => {
+                // Circom passes the caller's requested result size to generated
+                // functions. Some real-world circuits intentionally assign a
+                // shorter returned array to a wider destination; the generated
+                // WASM copies the zero-initialized tail in that case.
+                values.resize(result_size, Fr::from(0_u64));
+                values.truncate(result_size);
+                Ok(values)
+            }
+            Flow::Continue => bail!("runtime Circom function {} did not return", function.name),
+        }
+    }
+
+    fn execute_list(
+        &mut self,
+        statements: &[RuntimeStatement],
+        variables: &mut [Fr],
+    ) -> eyre::Result<Flow> {
+        for statement in statements {
+            self.step()?;
+            match statement {
+                RuntimeStatement::Store {
+                    offset,
+                    size,
+                    value,
+                } => {
+                    let offset = self.evaluate(offset, variables)?.address()?;
+                    let value = self.evaluate(value, variables)?.fields()?;
+                    if value.len() < *size {
+                        bail!("runtime Circom store source is shorter than its declared size");
+                    }
+                    let end = offset
+                        .checked_add(*size)
+                        .ok_or_else(|| eyre!("runtime Circom store overflowed"))?;
+                    let destination = variables
+                        .get_mut(offset..end)
+                        .ok_or_else(|| eyre!("runtime Circom store is out of bounds"))?;
+                    destination.copy_from_slice(&value[..*size]);
+                }
+                RuntimeStatement::Call(call) => {
+                    self.evaluate(call, variables)?;
+                }
+                RuntimeStatement::Branch {
+                    condition,
+                    if_branch,
+                    else_branch,
+                } => {
+                    let condition = self.evaluate(condition, variables)?.fields()?;
+                    let branch = if condition
+                        .first()
+                        .is_some_and(|value| *value != Fr::from(0_u64))
+                    {
+                        if_branch
+                    } else {
+                        else_branch
+                    };
+                    if let Flow::Return(values) = self.execute_list(branch, variables)? {
+                        return Ok(Flow::Return(values));
+                    }
+                }
+                RuntimeStatement::Loop { condition, body } => loop {
+                    let condition = self.evaluate(condition, variables)?.fields()?;
+                    if condition
+                        .first()
+                        .is_none_or(|value| *value == Fr::from(0_u64))
+                    {
+                        break;
+                    }
+                    if let Flow::Return(values) = self.execute_list(body, variables)? {
+                        return Ok(Flow::Return(values));
+                    }
+                },
+                RuntimeStatement::Return { value, size } => {
+                    let mut values = self.evaluate(value, variables)?.fields()?;
+                    values.truncate(*size);
+                    return Ok(Flow::Return(values));
+                }
+            }
+        }
+        Ok(Flow::Continue)
+    }
+
+    fn evaluate(
+        &mut self,
+        expression: &RuntimeExpression,
+        variables: &[Fr],
+    ) -> eyre::Result<Value> {
+        self.step()?;
+        Ok(match expression {
+            RuntimeExpression::Field(value) => Value::Fields(vec![Fr::new((*value).into())]),
+            RuntimeExpression::Address(value) => Value::Address(*value),
+            RuntimeExpression::Load { offset, size } => {
+                let offset = self.evaluate(offset, variables)?.address()?;
+                let end = offset
+                    .checked_add(*size)
+                    .ok_or_else(|| eyre!("runtime Circom load overflowed"))?;
+                Value::Fields(
+                    variables
+                        .get(offset..end)
+                        .ok_or_else(|| eyre!("runtime Circom load is out of bounds"))?
+                        .to_vec(),
+                )
+            }
+            RuntimeExpression::Compute {
+                operation,
+                operands,
+            } => {
+                let mut values = Vec::with_capacity(operands.len());
+                for operand in operands {
+                    values.push(self.evaluate(operand, variables)?);
+                }
+                match operation {
+                    RuntimeOperation::AddAddress | RuntimeOperation::MulAddress => {
+                        let mut values = values.into_iter();
+                        let left = values.next().unwrap().address()?;
+                        let right = values.next().unwrap().address()?;
+                        let value = if matches!(operation, RuntimeOperation::AddAddress) {
+                            left.checked_add(right)
+                        } else {
+                            left.checked_mul(right)
+                        }
+                        .ok_or_else(|| eyre!("runtime Circom address overflowed"))?;
+                        Value::Address(value)
+                    }
+                    RuntimeOperation::ToAddress => {
+                        let value: U256 = values.into_iter().next().unwrap().fields()?[0].into();
+                        Value::Address(
+                            usize::try_from(value)
+                                .map_err(|_| eyre!("runtime Circom address does not fit usize"))?,
+                        )
+                    }
+                    RuntimeOperation::Equal(size) => {
+                        let mut values = values.into_iter();
+                        let left = values.next().unwrap().fields()?;
+                        let right = values.next().unwrap().fields()?;
+                        if left.len() < *size || right.len() < *size || *size == 0 {
+                            bail!("invalid runtime Circom multi-value equality");
+                        }
+                        Value::Fields(vec![Fr::from(left[..*size] == right[..*size])])
+                    }
+                    RuntimeOperation::Field(operation) => {
+                        let mut values = values.into_iter();
+                        let left = values.next().unwrap().fields()?;
+                        let a = *left
+                            .first()
+                            .ok_or_else(|| eyre!("runtime Circom operation has no operand"))?;
+                        let b = if let Some(right) = values.next() {
+                            *right
+                                .fields()?
+                                .first()
+                                .ok_or_else(|| eyre!("runtime Circom operation has no operand"))?
+                        } else {
+                            a
+                        };
+                        Value::Fields(vec![operation.eval_fr(a, b)])
+                    }
+                }
+            }
+            RuntimeExpression::Call {
+                function,
+                arena_size,
+                result_size,
+                arguments,
+            } => {
+                let mut flattened = Vec::new();
+                for (argument, size) in arguments {
+                    let values = self.evaluate(argument, variables)?.fields()?;
+                    if values.len() < *size {
+                        bail!("runtime Circom call argument is shorter than its declared size");
+                    }
+                    flattened.extend_from_slice(&values[..*size]);
+                }
+                Value::Fields(self.call(*function, &flattened, *arena_size, *result_size)?)
+            }
+        })
+    }
+}
+
+fn evaluate_mod_inv(arguments: &[Fr], result_size: usize) -> eyre::Result<Vec<Fr>> {
+    if arguments.len() < 2 {
+        bail!("Circom mod_inv call is missing n and k");
+    }
+    let n = usize::try_from(BigUint::from(arguments[0]))
+        .map_err(|_| eyre!("Circom mod_inv limb width does not fit usize"))?;
+    let k = usize::try_from(BigUint::from(arguments[1]))
+        .map_err(|_| eyre!("Circom mod_inv limb count does not fit usize"))?;
+    if n == 0 || n > 256 || arguments.len() < 2 + 2 * k {
+        bail!("Circom mod_inv has invalid limb dimensions");
+    }
+
+    let compose = |limbs: &[Fr]| {
+        limbs
+            .iter()
+            .enumerate()
+            .fold(BigUint::from(0_u8), |value, (index, limb)| {
+                value + (BigUint::from(*limb) << (n * index))
+            })
+    };
+    let value = compose(&arguments[2..2 + k]);
+    // Circom specializes array parameters at each call site. The bigint
+    // library uses either k, 50, or 100 slots for the first operand, while
+    // only the first k slots carry limbs. Recover the second parameter's
+    // boundary and prefer the nonzero modulus candidate.
+    let modulus = [k, 50, 100]
+        .into_iter()
+        .filter(|operand_size| arguments.len() >= 2 + operand_size + k)
+        .map(|operand_size| compose(&arguments[2 + operand_size..2 + operand_size + k]))
+        .max()
+        .unwrap_or_default();
+    if modulus <= BigUint::from(2_u8) {
+        bail!("Circom mod_inv modulus must be greater than two");
+    }
+    let inverse = if value == BigUint::from(0_u8) {
+        value
+    } else {
+        value.modpow(&(&modulus - BigUint::from(2_u8)), &modulus)
+    };
+    let mask = (BigUint::from(1_u8) << n) - BigUint::from(1_u8);
+    let mut output = Vec::with_capacity(result_size);
+    for index in 0..result_size {
+        output.push(if index < k {
+            Fr::from((&inverse >> (n * index)) & &mask)
+        } else {
+            Fr::from(0_u64)
+        });
+    }
+    Ok(output)
+}
+
+pub(crate) fn evaluate(
+    functions: &[RuntimeFunction],
+    function: usize,
+    arguments: &[Fr],
+    arena_size: usize,
+    result_size: usize,
+) -> eyre::Result<Vec<Fr>> {
+    Interpreter {
+        functions,
+        steps_left: 100_000_000,
+    }
+    .call(function, arguments, arena_size, result_size)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn load(offset: usize) -> RuntimeExpression {
+        RuntimeExpression::Load {
+            offset: Box::new(RuntimeExpression::Address(offset)),
+            size: 1,
+        }
+    }
+
+    fn compute(
+        operation: Operation,
+        left: RuntimeExpression,
+        right: RuntimeExpression,
+    ) -> RuntimeExpression {
+        RuntimeExpression::Compute {
+            operation: RuntimeOperation::Field(operation),
+            operands: vec![left, right],
+        }
+    }
+
+    #[test]
+    fn runtime_loop_uses_input_dependent_control_flow() {
+        let function = RuntimeFunction {
+            name: "sum_to_n".to_owned(),
+            variable_count: 2,
+            body: vec![
+                RuntimeStatement::Loop {
+                    condition: load(0),
+                    body: vec![
+                        RuntimeStatement::Store {
+                            offset: RuntimeExpression::Address(1),
+                            size: 1,
+                            value: compute(Operation::Add, load(1), load(0)),
+                        },
+                        RuntimeStatement::Store {
+                            offset: RuntimeExpression::Address(0),
+                            size: 1,
+                            value: compute(
+                                Operation::Sub,
+                                load(0),
+                                RuntimeExpression::Field(U256::from(1_u64)),
+                            ),
+                        },
+                    ],
+                },
+                RuntimeStatement::Return {
+                    value: load(1),
+                    size: 1,
+                },
+            ],
+        };
+
+        assert_eq!(
+            evaluate(&[function], 0, &[Fr::from(4_u64)], 2, 1).unwrap(),
+            vec![Fr::from(10_u64)]
+        );
+    }
+
+    #[test]
+    fn bigint_mod_inv_specialization_uses_circom_limbs_and_zero_extends() {
+        let function = RuntimeFunction {
+            name: "mod_inv_22".to_owned(),
+            variable_count: 0,
+            body: Vec::new(),
+        };
+        let arguments = [4_u64, 2, 3, 0, 13, 0].map(Fr::from);
+
+        assert_eq!(
+            evaluate(&[function], 0, &arguments, 0, 4).unwrap(),
+            vec![
+                Fr::from(9_u64),
+                Fr::from(0_u64),
+                Fr::from(0_u64),
+                Fr::from(0_u64),
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Keep statically traceable witness computation in the optimized precomputed graph.
- Serialize portable runtime IR for input-dependent branches, loops, indexes, and multi-output function calls.
- Lower local-template ternaries to arithmetic selects when both branches are graph-safe.
- Match Circom zero-initialization and zero-extension semantics.
- Optimize bigint modular inversion.
- Bump the graph format to v3 while retaining readers for v2 and legacy graphs.
- Pin the Circom compiler revision used by both optimization levels.

## Why

Real-world circuits such as the ProveKit V1 WebAuthn and identity workloads contain control flow that depends on witness inputs. Static symbolic graph construction cannot choose those paths at build time. The runtime IR handles only those dynamic regions; the rest of each circuit remains in the optimized graph.

## Impact

Existing static circuits retain the graph-based fast path and old graph artifacts remain readable. Circuits with input-dependent control flow no longer require a circuit-specific workaround or full runtime interpretation.

The ProveKit benchmark harness, pinned circuit sources, methodology, and results are intentionally kept on the separate `codex/provekit-benchmark-reference` branch because that branch is for reference and is not intended to merge.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace` (21 tests passed)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`
